### PR TITLE
DTS: imx6qdl-mf0300: use PLL5 clock as parent clock for LVDS

### DIFF
--- a/arch/arm/boot/dts/imx6qdl-mf0300.dtsi
+++ b/arch/arm/boot/dts/imx6qdl-mf0300.dtsi
@@ -849,3 +849,12 @@
 				0x0000c000 0x1404a38e 0x00000000>;
 	};
 };
+
+&clks {
+	assigned-clocks =
+			<&clks IMX6QDL_CLK_LDB_DI0_SEL>,
+			<&clks IMX6QDL_CLK_LDB_DI1_SEL>;
+	assigned-clock-parents =
+			<&clks IMX6QDL_CLK_PLL5_VIDEO_DIV>,
+			<&clks IMX6QDL_CLK_PLL5_VIDEO_DIV>;
+};


### PR DESCRIPTION
By default LDB_DI0_IPU and LDB_DI1_IPU clocks use MMDC_CH1 clock as
source. But it can't be adjusted enough to fulfill display requirements.
As result, LVDS bus can't transmit data fast enough.

PLL5 (PLL_VIDEO) clock is designed for usage in video subsystem and it
can be adjusted in wide range. So use it for LVDS.

Note: on Android 4.4 and Android 6 systems this clocks was used too.