### PR TITLE
Drivers: input: evdev: ignore eGalax Inc touch device

### DIFF
--- a/drivers/input/evdev.c
+++ b/drivers/input/evdev.c
@@ -1456,8 +1456,18 @@ static const struct input_device_id evdev_ids[] = {
 
 MODULE_DEVICE_TABLE(input, evdev_ids);
 
+static bool evdev_match(struct input_handler *handler, struct input_dev *dev)
+{
+	/* Avoid EETI USB touchscreens */
+	#define VID_EETI 0x0EEF
+	if ((BUS_USB == dev->id.bustype) && (VID_EETI == dev->id.vendor))
+		return false;
+	return true;
+}
+
 static struct input_handler evdev_handler = {
 	.event		= evdev_event,
+	.match		= evdev_match, /* Added by EETI*/
 	.events		= evdev_events,
 	.connect	= evdev_connect,
 	.disconnect	= evdev_disconnect,


### PR DESCRIPTION
Apply patch according EETI_eGTouch_Android_Guide_v2.5f.pdf
2.2.b kernel 2.6.34 upwards topic patch version applied.
Only eGTouch_v2.5.5814 driver works now.