### PR TITLE
Drivers: input: joydev: ignore eGalax Inc touch device

### DIFF
--- a/drivers/input/joydev.c
+++ b/drivers/input/joydev.c
@@ -809,6 +809,10 @@ static bool joydev_match(struct input_handler *handler, struct input_dev *dev)
 	if (joydev_dev_is_absolute_mouse(dev))
 		return false;
 
+	/* Avoid EETI virtual devices */
+	#define VID_EETI 0x0EEF
+	if (( BUS_VIRTUAL == dev->id.bustype) && (VID_EETI == dev->id.vendor))
+		return false;
 	return true;
 }
 


### PR DESCRIPTION
Apply patch according EETI_eGTouch_Android_Guide_v2.5f.pdf
2.2.b kernel 2.6.34 upwards topic patch version applied.
Only eGTouch_v2.5.5814 driver works now.