### PR TITLE
Drivers: input: mousedev: ignore eGalax Inc touch device

### DIFF
--- a/drivers/input/mousedev.c
+++ b/drivers/input/mousedev.c
@@ -1053,8 +1053,21 @@ static const struct input_device_id mousedev_ids[] = {
 
 MODULE_DEVICE_TABLE(input, mousedev_ids);
 
+static bool mousedev_match(struct input_handler *handler, struct input_dev *dev)
+{
+	/* Avoid EETI USB touchscreens */
+	#define VID_EETI 0x0EEF
+	if ((BUS_USB == dev->id.bustype) && (VID_EETI == dev->id.vendor))
+		return false;
+	/* Avoid EETI virtual devices */
+	if ((BUS_VIRTUAL == dev->id.bustype) && (VID_EETI == dev->id.vendor))
+		return false;
+	return true;
+}
+
 static struct input_handler mousedev_handler = {
 	.event		= mousedev_event,
+	.match		= mousedev_match, /* Added by EETI */
 	.connect	= mousedev_connect,
 	.disconnect	= mousedev_disconnect,
 	.legacy_minors	= true,


### PR DESCRIPTION
Apply patch according EETI_eGTouch_Android_Guide_v2.5f.pdf
2.2.b kernel 2.6.34 upwards topic patch version applied.
Only eGTouch_v2.5.5814 driver works now.