### PR TITLE
DTS: imx6qdl-mf0300: define CMA region

### DIFF
--- a/arch/arm/boot/dts/imx6qdl-mf0300.dtsi
+++ b/arch/arm/boot/dts/imx6qdl-mf0300.dtsi
@@ -49,6 +49,20 @@
 		reg = <0x10000000 0x80000000>;
 	};
 
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		/* global autoconfigured region for contiguous allocations */
+		linux,cma {
+			compatible = "shared-dma-pool";
+			reusable;
+			size = <0x10000000>;  /* 256 MB */
+			linux,cma-default;
+		};
+	};
+
 	leds {
 		compatible = "gpio-leds";
 		pinctrl-names = "default";


### PR DESCRIPTION
define CMA region in device tree instead of passing `cma=size` to
kernel command line, this way gives more flexibility